### PR TITLE
Comment out aws include

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     // Default package configuration.
     pkg: grunt.file.readJSON('package.json'),
-    aws: grunt.file.readJSON('aws.json'),
+    // aws: grunt.file.readJSON('aws.json'),
 
     // Define a banner to added to the compiled assets.
     banner: "/* <%= pkg.name %> v<%= pkg.version %> | " +


### PR DESCRIPTION
Grunt will not run if this file is missing, probably for deployment and not needed here. If you want to edit include the file for those grunt tasks, that works too! Just trying to make it work on first run for people walking through tutorial on readme.
